### PR TITLE
Add agent-knowledge as git submodule

### DIFF
--- a/.claude/tasks.json
+++ b/.claude/tasks.json
@@ -1,0 +1,16 @@
+{
+  "version": "1.0.0",
+  "tasks": [
+    {
+      "id": "2",
+      "source": "agent-sh/agent-sh.dev",
+      "title": "Org Architecture: Documentation & Website Strategy",
+      "branch": "feature/org-docs-strategy-2",
+      "worktreePath": "/home/ubuntu/agent-sh/worktrees/org-docs-strategy-2",
+      "claimedAt": "2026-02-22T00:00:00Z",
+      "claimedBy": "worktree-manager",
+      "status": "claimed",
+      "lastActivityAt": "2026-02-22T00:00:00Z"
+    }
+  ]
+}

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "agent-knowledge"]
+	path = agent-knowledge
+	url = https://github.com/agent-sh/agent-knowledge.git


### PR DESCRIPTION
## Summary
- Adds `agent-knowledge` as a git submodule pointing to `agent-sh/agent-knowledge`
- Centralizes the shared knowledge base across all plugin repos
- Single source of truth - update once, pull everywhere

## Test plan
- [ ] Verify `git submodule update --init` works after clone
- [ ] Confirm knowledge files are accessible at `agent-knowledge/`