### PR TITLE
chore: update repo-map to repo-intel

### DIFF
--- a/src/data/plugins.json
+++ b/src/data/plugins.json
@@ -74,7 +74,7 @@
     "commands": 1,
     "repo": "https://github.com/agent-sh/drift-detect",
     "install": "agentsys install drift-detect",
-    "dependencies": ["repo-map"]
+    "dependencies": ["repo-intel"]
   },
   {
     "name": "audit-project",
@@ -88,14 +88,14 @@
     "dependencies": []
   },
   {
-    "name": "repo-map",
-    "description": "AST symbol and import mapping. Cached file-to-symbols map via ast-grep used by drift-detect and planners.",
+    "name": "repo-intel",
+    "description": "Unified static analysis via agent-analyzer. Git history, AST symbols, project metadata, and doc-code sync in one cached artifact.",
     "category": "infrastructure",
     "agents": 1,
     "skills": 1,
     "commands": 1,
-    "repo": "https://github.com/agent-sh/repo-map",
-    "install": "agentsys install repo-map",
+    "repo": "https://github.com/agent-sh/repo-intel",
+    "install": "agentsys install repo-intel",
     "dependencies": []
   },
   {

--- a/src/data/skills.json
+++ b/src/data/skills.json
@@ -21,7 +21,7 @@
   { "name": "perf-analyzer", "plugin": "perf", "description": "Deep performance analysis combining all profiling data", "platforms": ["Claude Code", "OpenCode", "Codex"] },
   { "name": "deslop", "plugin": "deslop", "description": "Detect and clean AI-generated slop patterns in code", "platforms": ["Claude Code", "OpenCode", "Codex"] },
   { "name": "drift-analysis", "plugin": "drift-detect", "description": "Compare documented plans against actual implementation", "platforms": ["Claude Code", "OpenCode", "Codex"] },
-  { "name": "repo-mapping", "plugin": "repo-map", "description": "Build AST-based symbol and import map of codebase", "platforms": ["Claude Code", "OpenCode", "Codex"] },
+  { "name": "repo-intel", "plugin": "repo-intel", "description": "Unified static analysis - git history, AST symbols, project metadata", "platforms": ["Claude Code", "OpenCode", "Codex"] },
   { "name": "sync-docs", "plugin": "sync-docs", "description": "Find and fix documentation drift from source code", "platforms": ["Claude Code", "OpenCode", "Codex"] },
   { "name": "learn-topic", "plugin": "learn", "description": "Research topics online and create structured learning guides", "platforms": ["Claude Code", "OpenCode", "Codex"] },
   { "name": "agnix-lint", "plugin": "agnix", "description": "Validate agent configs with 230 rules across AI tools", "platforms": ["Claude Code", "OpenCode", "Codex", "Cursor"] },


### PR DESCRIPTION
## Summary

- Update plugins.json: repo-map -> repo-intel with new description and repo URL
- Update skills.json: repo-mapping -> repo-intel
- Update drift-detect dependency from repo-map to repo-intel

## Test Plan

- [ ] Site builds and deploys