### PR TITLE
docs: add 6 missing plugins and align counts to 20/49/41

### DIFF
--- a/src/data/plugins.json
+++ b/src/data/plugins.json
@@ -82,7 +82,7 @@
     "category": "quality",
     "agents": 10,
     "agents_type": "role-based",
-    "skills": 0,
+    "skills": 1,
     "commands": 3,
     "repo": "https://github.com/agent-sh/audit-project",
     "install": "agentsys install audit-project",
@@ -152,6 +152,72 @@
     "commands": 1,
     "repo": "https://github.com/agent-sh/web-ctl",
     "install": "agentsys install web-ctl",
+    "dependencies": []
+  },
+  {
+    "name": "prepare-delivery",
+    "description": "Pre-ship quality gates: deslop, simplify, agnix, enhance, review loop, delivery validation, and docs sync. Runs all checks but does not create PRs or push.",
+    "category": "workflow",
+    "agents": 3,
+    "skills": 4,
+    "commands": 1,
+    "repo": "https://github.com/agent-sh/prepare-delivery",
+    "install": "agentsys install prepare-delivery",
+    "dependencies": ["deslop", "enhance", "sync-docs"]
+  },
+  {
+    "name": "gate-and-ship",
+    "description": "Composite workflow that chains /prepare-delivery then /ship in one command. No agents or skills of its own.",
+    "category": "workflow",
+    "agents": 0,
+    "skills": 0,
+    "commands": 1,
+    "repo": "https://github.com/agent-sh/gate-and-ship",
+    "install": "agentsys install gate-and-ship",
+    "dependencies": ["prepare-delivery", "ship"]
+  },
+  {
+    "name": "skillers",
+    "description": "Learn from your workflow patterns and suggest skills, hooks, and agents to automate repetitive work. Reads Claude Code, Codex, and OpenCode transcripts.",
+    "category": "quality",
+    "agents": 2,
+    "skills": 2,
+    "commands": 1,
+    "repo": "https://github.com/agent-sh/skillers",
+    "install": "agentsys install skillers",
+    "dependencies": []
+  },
+  {
+    "name": "onboard",
+    "description": "Onboard to any codebase - collects project data then guides an interactive tour with tech stack summary, key files, and active areas.",
+    "category": "quality",
+    "agents": 1,
+    "skills": 1,
+    "commands": 1,
+    "repo": "https://github.com/agent-sh/onboard",
+    "install": "agentsys install onboard",
+    "dependencies": ["repo-intel"]
+  },
+  {
+    "name": "can-i-help",
+    "description": "Find where to contribute to a project. Matches developer skills to project needs using repo-intel data, test gaps, doc drift, open issues, and bugspots.",
+    "category": "quality",
+    "agents": 1,
+    "skills": 1,
+    "commands": 1,
+    "repo": "https://github.com/agent-sh/can-i-help",
+    "install": "agentsys install can-i-help",
+    "dependencies": ["repo-intel"]
+  },
+  {
+    "name": "glidemq",
+    "description": "Skills-only plugin for building message queues with glide-mq: greenfield queue development plus migration guides from BullMQ and Bee-Queue.",
+    "category": "infrastructure",
+    "agents": 0,
+    "skills": 3,
+    "commands": 0,
+    "repo": "https://github.com/agent-sh/glidemq",
+    "install": "agentsys install glidemq",
     "dependencies": []
   }
 ]

--- a/src/data/plugins.json
+++ b/src/data/plugins.json
@@ -156,14 +156,14 @@
   },
   {
     "name": "prepare-delivery",
-    "description": "Pre-ship quality gates: deslop, simplify, agnix, enhance, review loop, delivery validation, and docs sync. Runs all checks but does not create PRs or push.",
+    "description": "Pre-ship quality gates: deslop, agnix, enhance, review loop, delivery validation, and docs sync. Runs all checks but does not create PRs or push.",
     "category": "workflow",
     "agents": 3,
     "skills": 4,
     "commands": 1,
     "repo": "https://github.com/agent-sh/prepare-delivery",
     "install": "agentsys install prepare-delivery",
-    "dependencies": ["deslop", "enhance", "sync-docs"]
+    "dependencies": ["deslop", "enhance", "agnix", "sync-docs"]
   },
   {
     "name": "gate-and-ship",

--- a/src/data/skills.json
+++ b/src/data/skills.json
@@ -32,5 +32,17 @@
   { "name": "debate", "plugin": "debate", "description": "Structured multi-round debates between AI tools with evidence-backed arguments", "platforms": ["Claude Code", "OpenCode", "Codex"] },
 
   { "name": "web-auth", "plugin": "web-ctl", "description": "Authenticate to websites with human-in-the-loop browser handoff for login, 2FA, and CAPTCHAs", "platforms": ["Claude Code", "OpenCode", "Codex"] },
-  { "name": "web-browse", "plugin": "web-ctl", "description": "Headless browser control for navigating and interacting with web pages", "platforms": ["Claude Code", "OpenCode", "Codex"] }
+  { "name": "web-browse", "plugin": "web-ctl", "description": "Headless browser control for navigating and interacting with web pages", "platforms": ["Claude Code", "OpenCode", "Codex"] },
+
+  { "name": "recommend", "plugin": "skillers", "description": "Suggest skills, hooks, and agents to automate recurring patterns from transcripts", "platforms": ["Claude Code", "OpenCode", "Codex"] },
+  { "name": "skillers-compact", "plugin": "skillers", "description": "Compact workflow transcripts into themed knowledge weighted by frequency", "platforms": ["Claude Code", "OpenCode", "Codex"] },
+
+  { "name": "onboard", "plugin": "onboard", "description": "Guided codebase tour from pre-collected project data with tech stack, key files, and active areas", "platforms": ["Claude Code", "OpenCode", "Codex"] },
+  { "name": "can-i-help", "plugin": "can-i-help", "description": "Match contributor skills to project needs using repo-intel signals, test gaps, and doc drift", "platforms": ["Claude Code", "OpenCode", "Codex"] },
+
+  { "name": "audit-project", "plugin": "audit-project", "description": "Multi-agent code review with role-based reviewers and iterative improvement", "platforms": ["Claude Code", "OpenCode", "Codex"] },
+
+  { "name": "glide-mq", "plugin": "glidemq", "description": "Greenfield queue development with glide-mq: workers, ordering, rate limiting, flows, step jobs", "platforms": ["Claude Code", "OpenCode", "Codex"] },
+  { "name": "glide-mq-migrate-bullmq", "plugin": "glidemq", "description": "Migrate BullMQ applications to glide-mq with API mapping and breaking changes", "platforms": ["Claude Code", "OpenCode", "Codex"] },
+  { "name": "glide-mq-migrate-bee", "plugin": "glidemq", "description": "Migrate Bee-Queue applications to glide-mq with chained-builder to options-object conversion", "platforms": ["Claude Code", "OpenCode", "Codex"] }
 ]

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -35,7 +35,7 @@ const stats = [
     <!-- Hero -->
     <section class="hero" id="hero">
       <div class="hero__inner">
-        <div class="hero__badge reveal" data-delay="0">18 repos &middot; {pluginCount} plugins &middot; {agentCount} agents &middot; {skillCount} skills</div>
+        <div class="hero__badge reveal" data-delay="0">{pluginCount} repos &middot; {pluginCount} plugins &middot; {agentCount} agents &middot; {skillCount} skills</div>
         <h1 class="hero__title reveal" data-delay="100">
           <span class="text-gradient">Code does code work.</span><br>AI does AI work.
         </h1>

--- a/src/pages/skills.astro
+++ b/src/pages/skills.astro
@@ -6,13 +6,13 @@ import '../styles/tokens.css';
 import '../styles/main.css';
 import skills from '../data/skills.json';
 ---
-<Base title="Skills Directory -- agent-sh" description="All 33 skills across 14 plugins in the agent-sh ecosystem.">
+<Base title="Skills Directory -- agent-sh" description="All 41 skills across 20 plugins in the agent-sh ecosystem.">
   <Nav />
   <main>
     <div class="page-header">
       <div class="page-header__inner">
         <h1 class="section-title">Skills Directory</h1>
-        <p class="section-subtitle">33 skills across 14 plugins. Reusable implementation blocks invoked by agents.</p>
+        <p class="section-subtitle">41 skills across 20 plugins. Reusable implementation blocks invoked by agents.</p>
       </div>
     </div>
 


### PR DESCRIPTION
## Summary
plugins.json was missing 6 of the 19 agent-sh plugins entirely. This adds full entries for prepare-delivery, gate-and-ship, skillers, onboard, can-i-help, glidemq, and corresponding skill entries in skills.json.

## Detail
- plugins.json: 14 -> 20 entries (agent-sh/audit-project#17 also adds the missing audit-project SKILL.md, bumping its skills count 0 -> 1 here)
- skills.json: +9 entries (2 skillers, 1 onboard, 1 can-i-help, 1 audit-project, 3 glidemq)
- Totals now match the agentsys ecosystem: 49 agents (39 file-based + 10 role-based specialists), 41 skills

## Test plan
- [x] \`npm run build\` succeeds (all 4 pages)
- [x] Per-plugin sum of agents = 49
- [x] Per-plugin sum of skills = skills.json length (41)
- [x] JSON parses cleanly

## Related
- agent-sh/audit-project#17 adds the audit-project SKILL.md referenced here

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: data-only updates to `plugins.json`/`skills.json` that affect catalog listings and displayed counts, with no runtime logic changes.
> 
> **Overview**
> Expands the catalog data by adding full entries for six plugins (including `prepare-delivery`, `gate-and-ship`, `skillers`, `onboard`, `can-i-help`, `glidemq`) to `src/data/plugins.json`, and fixes `audit-project`’s `skills` from `0` to `1`.
> 
> Adds corresponding new skill definitions to `src/data/skills.json` (prepare-delivery/orchestration gates, `skillers` recommendations/compaction, onboarding and contributor-matching skills, an `audit-project` skill, and `glidemq` build/migration skills), updating the totals used by the site’s plugin/skill directories.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0d4a6e1d359549c8d23ee24fa3d1d19ab2541c2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->