### PR TITLE
docs: clarify /simplify is third-party in prepare-delivery description

### DIFF
--- a/src/data/plugins.json
+++ b/src/data/plugins.json
@@ -156,7 +156,7 @@
   },
   {
     "name": "prepare-delivery",
-    "description": "Pre-ship quality gates: deslop, agnix, enhance, review loop, delivery validation, and docs sync. Runs all checks but does not create PRs or push.",
+    "description": "Pre-ship quality gates: deslop, agnix, enhance, review loop, delivery validation, docs sync, and /simplify when the user has it installed. Runs all checks but does not create PRs or push.",
     "category": "workflow",
     "agents": 3,
     "skills": 4,

--- a/src/data/plugins.json
+++ b/src/data/plugins.json
@@ -156,7 +156,7 @@
   },
   {
     "name": "prepare-delivery",
-    "description": "Pre-ship quality gates: deslop, agnix, enhance, review loop, delivery validation, docs sync, and /simplify when the user has it installed. Runs all checks but does not create PRs or push.",
+    "description": "Pre-ship quality gates: deslop, agnix, enhance, review loop, delivery validation, sync-docs, and /simplify when the user has it installed. Runs all checks but does not create PRs or push.",
     "category": "workflow",
     "agents": 3,
     "skills": 4,


### PR DESCRIPTION
## Summary
Restore mention of \`/simplify\` in the prepare-delivery plugin description with clearer "when the user has it installed" framing.

## Why
Earlier I removed \`simplify\` per a Gemini comment because it isn't a first-party agent-sh plugin. But prepare-delivery's skill *does* invoke \`/simplify\` opportunistically when available (see agent-sh/prepare-delivery#1 making it conditional). The description should reflect that opt-in third-party integration so users know it's wired up.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-string documentation update in `plugins.json`; no functional/runtime logic changes, so risk is minimal aside from wording accuracy on pages that display plugin metadata.
> 
> **Overview**
> Updates the `prepare-delivery` entry in `src/data/plugins.json` to explicitly mention that it will run `/simplify` *only when the user has it installed*, clarifying the optional third-party integration in the plugin description.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7681e8ac256ef2d6b7c91ee30e595c0ecc9d7fa5. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->