### PR TITLE
docs(plugins,skills): surface repo-intel v0.5 features (enrich, find, summary)

### DIFF
--- a/src/data/plugins.json
+++ b/src/data/plugins.json
@@ -90,9 +90,9 @@
   },
   {
     "name": "repo-intel",
-    "description": "Unified static analysis via agent-analyzer. Git history, AST symbols, project metadata, and doc-code sync in one cached artifact.",
+    "description": "Unified static analysis via agent-analyzer: git history, AST symbols, project metadata, doc-code sync, plus optional Haiku-augmented file descriptors and a 3-depth narrative summary for fast first-foothold in unfamiliar repos.",
     "category": "infrastructure",
-    "agents": 1,
+    "agents": 3,
     "skills": 1,
     "commands": 1,
     "repo": "https://github.com/agent-sh/repo-intel",

--- a/src/data/skills.json
+++ b/src/data/skills.json
@@ -23,7 +23,7 @@
   { "name": "perf-analyzer", "plugin": "perf", "description": "Deep performance analysis combining all profiling data", "platforms": ["Claude Code", "OpenCode", "Codex"] },
   { "name": "deslop", "plugin": "deslop", "description": "Detect and clean AI-generated slop patterns in code", "platforms": ["Claude Code", "OpenCode", "Codex"] },
   { "name": "drift-analysis", "plugin": "drift-detect", "description": "Compare documented plans against actual implementation", "platforms": ["Claude Code", "OpenCode", "Codex"] },
-  { "name": "repo-intel", "plugin": "repo-intel", "description": "Unified static analysis - git history, AST symbols, project metadata", "platforms": ["Claude Code", "OpenCode", "Codex"] },
+  { "name": "repo-intel", "plugin": "repo-intel", "description": "Unified static analysis - git history, AST symbols, project metadata, doc-code sync, concept search, plus Haiku-augmented file descriptors and a 3-depth narrative summary", "platforms": ["Claude Code", "OpenCode", "Codex"] },
   { "name": "sync-docs", "plugin": "sync-docs", "description": "Find and fix documentation drift from source code", "platforms": ["Claude Code", "OpenCode", "Codex"] },
   { "name": "learn-topic", "plugin": "learn", "description": "Research topics online and create structured learning guides", "platforms": ["Claude Code", "OpenCode", "Codex"] },
   { "name": "agnix-lint", "plugin": "agnix", "description": "Validate agent configs with 399 rules across AI tools", "platforms": ["Claude Code", "OpenCode", "Codex", "Cursor"] },


### PR DESCRIPTION
repo-intel landed three significant feature additions in v0.5 that weren't reflected in the website's plugin/skill catalog:

- Agent count was 1 (\`map-validator\`); now 3 with the addition of \`repo-intel-weighter\` and \`repo-intel-summarizer\` Haiku agents
- Description didn't mention LLM-augmented signals, find concept search, or post-init enrich

## Changes

\`src/data/plugins.json\`:
- repo-intel \`agents\`: 1 → 3
- repo-intel \`description\`: extended to mention "Haiku-augmented file descriptors and a 3-depth narrative summary for fast first-foothold in unfamiliar repos"

\`src/data/skills.json\`:
- repo-intel skill description extended with "concept search" + "Haiku-augmented file descriptors and 3-depth narrative summary"

The aggregate "X agents" badge on the homepage is computed dynamically from plugins.json (\`reduce\` over \`.agents\`), so it'll auto-update from 49 → 51.

## Test plan

- [x] \`npm run build\` — clean (4 pages built)
- [ ] CI green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation/data-only update; the only behavioral change is any UI that derives counts (e.g., total agents) will reflect the updated `repo-intel` agent number.
> 
> **Overview**
> Updates the `repo-intel` entries in `src/data/plugins.json` and `src/data/skills.json` to reflect v0.5 capabilities, expanding the descriptions to mention doc-code sync, concept search, and optional Haiku-augmented metadata/summaries.
> 
> Also increases `repo-intel`’s advertised `agents` count from `1` to `3`, which will affect any aggregate agent totals computed from `plugins.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54f0daea98f0fb99ca6e7f65fb494760016d78ef. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->